### PR TITLE
Clarify time format and base directory in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ PVOUTPUT_ENABLED=false
 # TOU SETTINGS (if TOU_ENABLED=true)
 # ==============================================================================
 # Peak period start hour (24-hour format)
-# Examples: 17 = 5 PM, 14 = 2 PM, 16 = 4 PM
+# Examples: 17 = 5 PM, 14 = 2 PM, 16 = 4 PM, may use HH:MM format
 PEAK_START_HOUR=17
 
 # Peak period end hour (24-hour format)
@@ -190,6 +190,7 @@ CHARGING_STRATEGY=balanced
 # SYSTEM PATHS
 # ==============================================================================
 # Base directory for logs and data (relative paths also work)
+# For Debian / Raspberry Pi use /app for base dir
 # Default works for Synology NAS setup
 BASE_DIR=/volume1/docker/franklin
 


### PR DESCRIPTION
Updated comments in .env.example to clarify time format and base directory usage.