### PR TITLE
Enable debug logging

### DIFF
--- a/scripts/collect_enphase.py
+++ b/scripts/collect_enphase.py
@@ -30,6 +30,7 @@ import sys
 import time
 import argparse
 import logging
+from config import configure_logging
 from datetime import datetime
 from pathlib import Path
 
@@ -252,14 +253,7 @@ except ImportError:
 
 # ── Logging ─────────────────────────────────────────────────────
 LOG_DIR.mkdir(parents=True, exist_ok=True)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler(LOG_DIR / "enphase_collector.log"),
-        logging.StreamHandler(),
-    ],
-)
+configure_logging(log_file=LOG_DIR / "enphase_collector.log")
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/collect_solaredge.py
+++ b/scripts/collect_solaredge.py
@@ -28,6 +28,7 @@ Output format matches collect_enphase.py for dashboard compatibility.
 import argparse
 import json
 import logging
+from config import configure_logging
 import os
 import sys
 import time
@@ -52,14 +53,7 @@ except ImportError:
     pass
 
 LOG_DIR.mkdir(parents=True, exist_ok=True)
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler(LOG_DIR / "solaredge_collector.log"),
-        logging.StreamHandler(),
-    ],
-)
+configure_logging(log_file=LOG_DIR / "solaredge_collector.log")
 logger = logging.getLogger(__name__)
 
 # SolarEdge API base

--- a/scripts/collect_solaredge_panels.py
+++ b/scripts/collect_solaredge_panels.py
@@ -49,16 +49,14 @@ import csv
 import json
 import time
 import logging
+from config import configure_logging
 import argparse
 import requests
 from datetime import datetime, date, timedelta
 from pathlib import Path
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
-)
+configure_logging()
 logger = logging.getLogger(__name__)
 
 # Paths

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -578,6 +578,21 @@ class Config:
 config = Config()
 
 
+def configure_logging(log_file=None):
+    """Configure root logger based on DEBUG_MODE env var."""
+    import logging
+    level = logging.DEBUG if config.DEBUG_MODE else logging.INFO
+    handlers = [logging.StreamHandler()]
+    if log_file is not None:
+        handlers.append(logging.FileHandler(log_file))
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=handlers,
+    )
+
+
 if __name__ == "__main__":
     # When run directly, print configuration summary
     print(config.get_config_summary())

--- a/scripts/data_sources.py
+++ b/scripts/data_sources.py
@@ -43,7 +43,7 @@ except ImportError:
 from franklinwh import Client, TokenFetcher
 
 # Local config
-from config import config
+from config import config, configure_logging
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -1008,6 +1008,7 @@ async def switch_battery_mode(mode: str) -> bool:
 
 if __name__ == "__main__":
     """Test the data source manager."""
+    configure_logging()
     import sys
 
     async def test():

--- a/scripts/scheduler.py
+++ b/scripts/scheduler.py
@@ -52,7 +52,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 # Import config to check enabled features
 try:
-    from config import config
+    from config import config, configure_logging
     CONFIG_LOADED = True
 except ImportError:
     print("Warning: Could not load config, using defaults")
@@ -643,6 +643,7 @@ def start_api_server():
 
 def main():
     """Main entry point."""
+    configure_logging()
     start_api_server()
     setup_schedule()
     

--- a/scripts/smart_decision.py
+++ b/scripts/smart_decision.py
@@ -52,7 +52,7 @@ import csv
 from datetime import datetime, timedelta
 
 # Import configuration and data sources
-from config import config, is_peak_period
+from config import config, configure_logging, is_peak_period
 from data_sources import get_battery_data, switch_battery_mode, data_manager
 
 # Optional imports for enabled features
@@ -428,7 +428,7 @@ def check_manual_override() -> dict:
 
 async def main() -> int:
     """Main automation logic."""
-    
+    configure_logging()
     try:
         log_intelligence("=" * 70)
         log_intelligence("FranklinWH Smart Decision Engine v3.5.1")

--- a/scripts/telemetry.py
+++ b/scripts/telemetry.py
@@ -43,7 +43,7 @@ from pathlib import Path
 import aiohttp
 import asyncio
 
-from config import config
+from config import config, configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -313,7 +313,7 @@ def log_telemetry_transparency():
 
 if __name__ == "__main__":
     """Test telemetry collection."""
-    
+    configure_logging()
     async def test():
         print("FranklinWH Battery Automation - Telemetry Test")
         print(f"Telemetry enabled: {config.TELEMETRY_ENABLED}")


### PR DESCRIPTION
Debug was a config option but never used in the log handlers. Centralized the log handler setup and included in scripts.

* Added the `configure_logging` function to `config.py`, allowing logging to be configured based on environment variables and optional log file paths.
* Replaced direct calls to `logging.basicConfig` in `scripts/collect_enphase.py`, `scripts/collect_solaredge.py`, and `scripts/collect_solaredge_panels.py` with `configure_logging`, ensuring consistent logging setup and supporting log file output. 
* Updated script entry points in `scripts/data_sources.py`, `scripts/scheduler.py`, `scripts/smart_decision.py`, and `scripts/telemetry.py` to call `configure_logging()` at startup, ensuring proper logger setup for each script. 
* Modified imports in all affected scripts to include `configure_logging` from `config.py`. 